### PR TITLE
FIXED: use Buffer.from(string) instead of Buffer(string), fixes Node …

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -50,7 +50,7 @@ var /*TYPE = {
       552: 'Requested file action aborted / Exceeded storage allocation (for current directory or dataset)',
       553: 'Requested action not taken / File name not allowed'
     },*/
-    bytesNOOP = new Buffer('NOOP\r\n');
+    bytesNOOP = Buffer.from('NOOP\r\n');
 
 var FTP = module.exports = function() {
   if (!(this instanceof FTP))
@@ -743,12 +743,12 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
   if (!recursive) {
     return this._send('RMD ' + path, cb);
   }
-  
+
   var self = this;
   this.list(path, function(err, list) {
     if (err) return cb(err);
     var idx = 0;
-    
+
     // this function will be called once per listing entry
     var deleteNextEntry;
     deleteNextEntry = function(err) {
@@ -760,9 +760,9 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
           return self.rmdir(path, cb);
         }
       }
-      
+
       var entry = list[idx++];
-      
+
       // get the path to the file
       var subpath = null;
       if (entry.name[0] === '/') {
@@ -776,7 +776,7 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
           subpath = path + '/' + entry.name
         }
       }
-      
+
       // delete the entry (recursively) according to its type
       if (entry.type === 'd') {
         if (entry.name === "." || entry.name === "..") {


### PR DESCRIPTION
Fixes Node 10 deprecated warning, see: https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding